### PR TITLE
Fix Chinese Search Bug

### DIFF
--- a/questionnaires/main.py
+++ b/questionnaires/main.py
@@ -242,6 +242,11 @@ def write_to_markdown(universities: dict, filename_map: FilenameMap, archived: b
         if archived:
             name += ' (已归档)'
         folder_name = join_path('dist', 'docs')
+
+        # Ignored samples with excessively long names
+        if len(filename) > 150:
+            continue
+
         with open(join_path(folder_name, filename), 'w', encoding='utf-8') as f:
             # write header
             f.write(f'# {name}\n\n')

--- a/questionnaires/main.py
+++ b/questionnaires/main.py
@@ -243,10 +243,6 @@ def write_to_markdown(universities: dict, filename_map: FilenameMap, archived: b
             name += ' (已归档)'
         folder_name = join_path('dist', 'docs')
 
-        # Ignored samples with excessively long names
-        if len(filename) > 150:
-            continue
-
         with open(join_path(folder_name, filename), 'w', encoding='utf-8') as f:
             # write header
             f.write(f'# {name}\n\n')

--- a/questionnaires/mkdocs_template.yml
+++ b/questionnaires/mkdocs_template.yml
@@ -38,6 +38,7 @@ theme:
     code: Roboto Mono
   features:
     - instant
+  custom_dir: overrides
 
 extra:
   social:
@@ -59,7 +60,10 @@ markdown_extensions:
 
 plugins:
   - search:
-      lang: ja
-      indexing: titles
+      lang: 
+        - ja
+        - en
+      indexing: 'titles'
       min_search_length: 2
+      separator: '[\s\-\.]+'
   - awesome-pages

--- a/questionnaires/site/overrides/main.html
+++ b/questionnaires/site/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block config %}
+  <script>
+    var search = {
+        transform: function(query) {
+            query = query + ' astopwordflagbylorenzo'; // Trigger stop-word mechanism
+            return query
+                .replace(/(?:^|\s+)[*+-:^~]+(?=\s+|$)/g, "")
+                .trim()
+                .replace(/\s+|\b$/g, "* ")
+        }
+    }
+  </script>
+{% endblock %}


### PR DESCRIPTION
<!-- 注意：如果您需要提交信息，请通过表单，谢谢合作！ -->

<!-- 目前因 workflow 问题，`/questionnaires` 目录完全由脚本从问卷生成。 -->
<!-- 直接修改 `/questionnaires` 目录内文件的 PR 会被强制覆盖。 -->
<!-- 问卷地址：https://submit.colleges.chat/ -->
<!-- 如果只希望补充部分信息，可将其它问题的回答留空。 -->

<!-- 确认无误后，请将下一行行首的 [ ] 修改为 [x]： -->
- [x] 我已阅读说明，并确认此 PR 不适用问卷提交或修改。
<!-- 感谢您的贡献！ -->

<!-- 如有补充说明，请从下一行开始书写。 -->

## Description

As discussed in #138 , at the moment searching with full university name does not work.

## Bug Reproduce

As shown in the following figures, NJUST, for example, was included in the dataset, but no corresponding results were found in the search box.

![image](https://github.com/CollegesChat/university-information/assets/42567930/71b08935-c9b1-42bb-83cd-0b0eadb2de05)

![image](https://github.com/CollegesChat/university-information/assets/42567930/c96986b7-a3f7-4fdf-bc23-5147be866191)

## Solution Effect

As shown in the following figure, NJUST, including its multiple campuses, has been correctly displayed. 

![image](https://github.com/CollegesChat/university-information/assets/42567930/e94c8293-60f5-487b-853e-825a0b5f4b7c)

In addition, searching suggestions are provided while typing.

![image](https://github.com/CollegesChat/university-information/assets/42567930/b551aae2-615b-4323-b31e-8af9a0878fd4)


> PS: It occurs that some samples with too long title name are unable to be wriiten when building site. Thus, I take the liberty of filtering them out. However, in terms of results, all those samples filtered out are negative sample. 